### PR TITLE
POD5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Requires path to reads in fast5 (squiggle) format and a matched mapped .bam/.sam
             -o      Prefix for output files <default: './output'>.
             --threads
                     Number of threads used <default: # of available cpus - 1>.
+            -F      File type. Use p for pod5 and f for fast5.
         More option on the candidate splice junctions (optional):
             By default, for each JWR, NanoSplicer includes the mapped splice junction and all GT-AG 
             junctions nearby, use the following options to choose candidates in different ways.

--- a/bin/NanoSplicer.py
+++ b/bin/NanoSplicer.py
@@ -243,7 +243,7 @@ def parse_arg():
             find_ATAC = True
         elif opt == "--provided_junction_only":
             provided_junction_only = True
-        elif opt in ("-ft", "--file_type"):
+        elif opt in ("-F", "--file_type"):
             file_type = arg
 
     # import global variable from config file 

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -217,35 +217,7 @@ class Fast5Class(object):
 
 		return(signal[start:end])
 
-	def get_alignment(self, output=None):
-		with h5py.File(self.filename, 'r') as h5_f:
-			path = "Analyses/"
-			subpath = list(h5_f[path].keys())
 			
-			for i in subpath:
-				if "RawGenomeCorrected" in i:
-					path = path + i +'/BaseCalled_template/'
-
-			try:
-				self.mapped = dict(h5_f[path]["Alignment"].attrs)
-				self.events = np.array(h5_f[path]["Events"])
-				self.read_start_rel_to_raw = \
-					h5_f[path]["Events"].attrs['read_start_rel_to_raw']
-				self.norm_shift = h5_f[path].attrs['shift']
-				 # rescale MAD to sd (https://en.wikipedia.org/wiki/Median_absolute_deviation)
-				self.norm_scale = h5_f[path].attrs['scale']*1.4826
-			except:
-				print("Alignment doesn't exist in fast5!!")
-				self.mapped = False
-			
-			if output == "mapping_info":
-				return self.mapped
-			elif output == "events":
-				return self.events
-			elif output == "norm_params":
-				return self.norm_shift, self.norm_scale
-			else:
-				return None
 	def remove_outlier(self, normalised_signal, thresh = 3):
 		'''
 		remove the data points in signal whose obsolute value reaches the thresh.

--- a/conda_env/environment.yml
+++ b/conda_env/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - pip:
     - ont_fast5_api
     - tables
+    - pod5


### PR DESCRIPTION
There is now an optional command line option -F for NanoSplicer.py to specify the filetype (POD5 or fast5). If this option is not used, the program will still identify the type from the file extension. 

